### PR TITLE
Activities location limiter, hide fields on new datasets

### DIFF
--- a/DataTracker/js/controllers/activities-controller.js
+++ b/DataTracker/js/controllers/activities-controller.js
@@ -160,8 +160,8 @@ var datasetActivitiesController = ['$scope','$routeParams', 'DataService', 'Data
             //performance idea: if project-role evaluation ends up being slow, you can conditionally include here...
           	var editButtonTemplate = '<div project-role="editor" class="ngCellText" ng-class="col.colIndex()">' +
             				   '<a href="#/edit/{{row.getProperty(\'Id\')}}">Edit</a>' +
-            				   '</div>';
-
+            				   '</div>';						   
+							   
             $scope.columnDefs = [
                         {field:'ActivityDate', displayName:'Activity Date', cellTemplate: linkTemplate, width:'100px'},
 
@@ -414,10 +414,20 @@ var datasetActivitiesController = ['$scope','$routeParams', 'DataService', 'Data
             };
 
             $scope.reloadProjectLocations = function(){
-
-                $scope.locationsArray = getUnMatchingByField($scope.project.Locations,PRIMARY_PROJECT_LOCATION_TYPEID,"LocationTypeId");
-
-                $scope.locationObjectIds = getLocationObjectIdsByInverseType(PRIMARY_PROJECT_LOCATION_TYPEID,$scope.project.Locations);
+				console.log("Inside $scope.reloadProjectLocations...");
+				console.log("$scope.project.Locations is next...");
+				console.dir($scope.project.Locations);
+				
+				$scope.datasetLocationType = DatastoreService.getDatasetLocationType($scope.DatastoreTablePrefix);			
+				console.log("LocationType = " + $scope.datasetLocationType);				
+				
+                //$scope.locationsArray = getUnMatchingByField($scope.project.Locations,PRIMARY_PROJECT_LOCATION_TYPEID,"LocationTypeId");
+                $scope.locationsArray = getMatchingByField($scope.project.Locations,$scope.datasetLocationType,"LocationTypeId");
+			
+                //$scope.locationObjectIds = getLocationObjectIdsByInverseType(PRIMARY_PROJECT_LOCATION_TYPEID,$scope.project.Locations);
+                $scope.locationObjectIds = getLocationObjectIdsByInverseType($scope.datasetLocationType,$scope.project.Locations);
+				console.log("$scope.locationObjectIds is next...");
+				console.dir($scope.locationObjectIds);
 
                 if($scope.map && $scope.map.locationLayer && $scope.map.locationLayer.hasOwnProperty('showLocationsById'))
                     $scope.map.locationLayer.showLocationsById($scope.locationObjectIds); //bump and reload the locations.
@@ -434,6 +444,10 @@ var datasetActivitiesController = ['$scope','$routeParams', 'DataService', 'Data
             $scope.$watch('dataset.Fields', function() {
                 if(!$scope.dataset.Fields ) return;
                 //load our project based on the projectid we get back from the dataset
+				
+				$scope.DatastoreTablePrefix = $scope.dataset.Datastore.TablePrefix;
+				console.log("$scope.DatastoreTablePrefix = " + $scope.DatastoreTablePrefix);				
+				
                 $scope.project = DataService.getProject($scope.dataset.ProjectId);
                 $scope.QAStatusList = makeObjects($scope.dataset.QAStatuses, 'Id','Name');
 

--- a/DataTracker/js/controllers/dataedit-controllers.js
+++ b/DataTracker/js/controllers/dataedit-controllers.js
@@ -169,7 +169,8 @@ mod_edit.controller('DataEditCtrl', ['$scope','$q','$sce','$routeParams','DataSe
 
 					$scope.RowQAStatuses =  $rootScope.RowQAStatuses = makeObjects($scope.dataset.RowQAStatuses, 'Id', 'Name');  //Row qa status ids
 
-					if($scope.dataset.RowQAStatuses.length > 1)
+					//if($scope.dataset.RowQAStatuses.length > 1)
+		    		if (($scope.dataset.Datastore.TablePrefix !== "FishScales") && ($scope.dataset.RowQAStatuses.length > 1))						
 					{
 						$scope.datasheetColDefs.push(
 								{

--- a/DataTracker/js/controllers/dataentry-controllers.js
+++ b/DataTracker/js/controllers/dataentry-controllers.js
@@ -63,6 +63,7 @@ mod_de.controller('DataEntryDatasheetCtrl', ['$scope','$routeParams','DataServic
 		$scope.datasetLocations = [[]];	
 		$scope.datasetLocationType=0;		
 		$scope.primaryProjectLocation = 0;
+		$scope.primaryDatasetLocation = 0;		
 		$scope.sortedLocations = [];
         
 		//datasheet grid definition
@@ -87,31 +88,75 @@ mod_de.controller('DataEntryDatasheetCtrl', ['$scope','$routeParams','DataServic
         $scope.$watch('project.Name', function(){
         	if(!$scope.project) return;
 
-        	//console.dir($scope.project);
+			console.log("Inside project.Name watcher...");
+			console.log("$scope is next...");
+        	console.dir($scope);
 			//$scope.locationOptions = $rootScope.locationOptions = makeObjects(getUnMatchingByField($scope.project.Locations,PRIMARY_PROJECT_LOCATION_TYPEID,"LocationTypeId"), 'Id','Label') ; // Original line
 
 			$scope.datasetLocationType = DatastoreService.getDatasetLocationType($scope.DatastoreTablePrefix);
-			console.log("LocationType = " + $scope.datasetLocationType);			
+			console.log("LocationType = " + $scope.datasetLocationType);
+			console.log("$scope.row is next...");
+			console.dir($scope.row);
 
 			console.log("ProjectLocations is next...");
 			console.dir($scope.project.Locations);
 			//var locInd = 0;
 			for (var i = 0; i < $scope.project.Locations.length; i++ )
 			{
-				//console.log("projectLocations Index = " + $scope.project.Locations[i].Label);
-				//console.log($scope.project.Locations[i].Id + "  " + $scope.project.Locations[i]);
+				console.log("projectLocations Index = " + $scope.project.Locations[i].Label);
+				console.log($scope.project.Locations[i].Id + "  " + $scope.project.Locations[i].LocationTypeId);
 				if ($scope.project.Locations[i].LocationTypeId === $scope.datasetLocationType)
 				{
-					//console.log("Found one");
-					$scope.datasetLocations.push([$scope.project.Locations[i].Id, $scope.project.Locations[i].Label]);
-					//console.log("datasetLocations length = " + $scope.datasetLocations.length);
-					//locInd++;
-				}
+					console.log("Found one");
+					// If the label is blank, this item is the Primary Project Location, and the label is null.
+					if ((typeof $scope.project.Locations[i].Label !== 'undefined') && ($scope.project.Locations[i].Label != null))
+					{	
+						var strLabel = $scope.project.Locations[i].Label.toLowerCase();
+						console.log("strLabel = " + strLabel);
+						var intLabelLength = strLabel.length;
+						var strHomeText = "home base";
+						console.log("strHomeText = " + strHomeText);
+						var intHomeTextLength = strHomeText.length;
+
+						// If we do indexOf on a string that is smaller than the search string, the results may be unpredictable,
+						// so let's verify the search string is bigger than the label string first.
+						if ((intLabelLength > intHomeTextLength) && (strLabel.indexOf(strHomeText) > -1))
+						{
+							console.log("Found Primary Dataset Location...");
+							$scope.primaryDatasetLocation = $scope.project.Locations[i].Id;
+							
+							// The form version uses this.
+							//$scope.row['locationId'] = $scope.primaryDatasetLocation;
+							//console.log("$scope.row is next...");
+							//console.dir($scope.row);
+
+							// The datasheet version uses this.
+							$scope.dataSheetDataset[0].locationId = $scope.primaryDatasetLocation; // The datasheet version uses this.	
+							console.log("$scope.dataSheetDataset is next...");
+							console.dir($scope.dataSheetDataset);
+						}
+						
+						$scope.datasetLocations.push([$scope.project.Locations[i].Id, $scope.project.Locations[i].Label]);
+						//console.log("datasetLocations length = " + $scope.datasetLocations.length);
+						//locInd++;
+					}
+					else
+					{
+						//$scope.primaryProjectLocation = $scope.project.Locations[i].Id;
+						//console.log("**Found a primary location.  LocId = " + $scope.primaryProjectLocation);
+					}
+				}					
 				else if ($scope.project.Locations[i].LocationTypeId === 3)
 				{
 					//$scope.datasetLocations.push([$scope.project.Locations[i].Id, $scope.project.Locations[i].Label]);  // The label is NULL, so do not add it.
 					$scope.primaryProjectLocation = $scope.project.Locations[i].Id;
-					console.log("Found a primary location.  LocId = " + $scope.primaryProjectLocation);
+					console.log("Found primary location.  LocId = " + $scope.primaryProjectLocation);
+					/*if ($scope.datasetLocationType === 104) 
+					{
+						$scope.row['locationId'] = $scope.primaryProjectLocation;
+						console.log("$scope.row is next...");
+						console.dir($scope.row);
+					}*/
 				}					
 			}
 			console.log("datasetLocations is next...");
@@ -250,7 +295,7 @@ mod_de.controller('DataEntryDatasheetCtrl', ['$scope','$routeParams','DataServic
 
 			var sheetCopy = angular.copy($scope.dataSheetDataset);
 
-            $scope.activities = ActivityParser.parseActivitySheet(sheetCopy, $scope.fields);
+            $scope.activities = ActivityParser.parseActivitySheet(sheetCopy, $scope.fields);  // Note:  The sheet version calls parseSingleActivity here.
             
             if(!$scope.activities.errors)
             {
@@ -285,6 +330,7 @@ mod_de.controller('DataEntryFormCtrl', ['$scope','$routeParams','DataService','$
 		$scope.datasetLocations = [[]];	
 		$scope.datasetLocationType=0;		
 		$scope.primaryProjectLocation = 0;
+		$scope.primaryDatasetLocation = 0;
 		$scope.sortedLocations = [];		
         
 		//datasheet grid
@@ -308,12 +354,15 @@ mod_de.controller('DataEntryFormCtrl', ['$scope','$routeParams','DataService','$
         //update our location options as soon as our project is loaded.
         $scope.$watch('project.Name', function(){
         	if(!$scope.project) return;
-        	//console.dir($scope.project);
+        	
+			console.log("Inside project.Name watcher...");
+			console.log("$scope is next...");
+			console.dir($scope);
 
 			//$scope.locationOptions = $rootScope.locationOptions = makeObjects(getUnMatchingByField($scope.project.Locations,PRIMARY_PROJECT_LOCATION_TYPEID,"LocationTypeId"), 'Id','Label') ; // Original code		
 			
 			$scope.datasetLocationType = DatastoreService.getDatasetLocationType($scope.DatastoreTablePrefix);			
-			console.log("LocationType = " + $scope.datasetLocationType);			
+			console.log("LocationType = " + $scope.datasetLocationType);
 			
 			console.log("ProjectLocations is next...");
 			if ($scope.project.Locations)
@@ -322,34 +371,61 @@ mod_de.controller('DataEntryFormCtrl', ['$scope','$routeParams','DataService','$
 			//var locInd = 0;
 			for (var i = 0; i < $scope.project.Locations.length; i++ )
 			{
-				console.log("i = " + i);
-				console.log($scope.project.Locations[i].Id + "  " + $scope.project.Locations[i].Label);
-				console.log("$scope.datasetLocationType = " + $scope.datasetLocationType + "  $scope.project.Locations[i].LocationTypeId = " + $scope.project.Locations[i].LocationTypeId);
+				//console.log("i = " + i);
+				//console.log($scope.project.Locations[i].Id + "  " + $scope.project.Locations[i].Label);
+				//console.log("$scope.datasetLocationType = " + $scope.datasetLocationType + "  $scope.project.Locations[i].LocationTypeId = " + $scope.project.Locations[i].LocationTypeId);
 				if ($scope.project.Locations[i].LocationTypeId === $scope.datasetLocationType)
 				{
 					console.log("Found one");
 					// If the label is blank, this item is the Primary Project Location, and the label is null.
 					if ((typeof $scope.project.Locations[i].Label !== 'undefined') && ($scope.project.Locations[i].Label != null))
 					{	
+						var strLabel = $scope.project.Locations[i].Label.toLowerCase();
+						console.log("strLabel = " + strLabel);
+						var intLabelLength = strLabel.length;
+						var strHomeText = "home base";
+						console.log("strHomeText = " + strHomeText);
+						var intHomeTextLength = strHomeText.length;
+
+						// If we do indexOf on a string that is smaller than the search string, the results may be unpredictable,
+						// so let's verify the search string is bigger than the label string first.
+						if ((intLabelLength > intHomeTextLength) && (strLabel.indexOf(strHomeText) > -1))
+						{
+							console.log("Found Primary Dataset Location...");
+							$scope.primaryDatasetLocation = $scope.project.Locations[i].Id;
+							
+							// The form version uses this.							
+							$scope.row['locationId'] = $scope.primaryDatasetLocation;
+							console.log("$scope.row is next...");
+							console.dir($scope.row);
+							
+							// The datasheet version uses this.
+							//$scope.dataSheetDataset[0].locationId = $scope.primaryDatasetLocation; // The datasheet version uses this.	
+							//console.log("$scope.dataSheetDataset is next...");
+							//console.dir($scope.dataSheetDataset);							
+						}
+						
 						$scope.datasetLocations.push([$scope.project.Locations[i].Id, $scope.project.Locations[i].Label]);
 						//console.log("datasetLocations length = " + $scope.datasetLocations.length);
 						//locInd++;
 					}
 					else
 					{
-						$scope.primaryProjectLocation = $scope.project.Locations[i].Id;
-						console.log("**Found a primary location.  LocId = " + $scope.primaryProjectLocation);
+						//$scope.primaryProjectLocation = $scope.project.Locations[i].Id;
+						//console.log("**Found a primary location.  LocId = " + $scope.primaryProjectLocation);
 					}
 				}
 				else if ($scope.project.Locations[i].LocationTypeId === 3)
 				{
 					//$scope.datasetLocations.push([$scope.project.Locations[i].Id, $scope.project.Locations[i].Label]);  // The label is NULL, so do not add it.
 					$scope.primaryProjectLocation = $scope.project.Locations[i].Id;
-					console.log("Found a primary location.  LocId = " + $scope.primaryProjectLocation);
+					console.log("Found primary location.  LocId = " + $scope.primaryProjectLocation);					
 				}					
 			}
 			console.log("datasetLocations is next...");
 			console.dir($scope.datasetLocations);
+			console.log("$scope.primaryProjectLocation = " + $scope.primaryProjectLocation);
+			console.log("$scope.primaryDatasetLocation = " + $scope.primaryDatasetLocation);
 			
 			// When we built the array, it started adding at location 1 for some reason, skipping 0.
 			// Therefore, row 0 is blank.  The simple solution is to just delete row 0.
@@ -683,9 +759,15 @@ mod_de.controller('DataEntryFormCtrl', ['$scope','$routeParams','DataService','$
 					//console.log("Ok our new list of files: "+$scope.row[field]);
 				});
 
-				var sheetCopy = angular.copy($scope.dataSheetDataset);		
-
-				$scope.activities = ActivityParser.parseSingleActivity($scope.row, sheetCopy, $scope.fields);
+				var sheetCopy = angular.copy($scope.dataSheetDataset);
+				console.log("sheetCopy is next...");
+				console.dir(sheetCopy);
+				
+				console.log("$scope.row is next");
+				console.dir($scope.row);
+				console.log("$scope.fields");
+				console.dir($scope.fields);
+				$scope.activities = ActivityParser.parseSingleActivity($scope.row, sheetCopy, $scope.fields); // Note:  The sheet version calls parseActivitySheet here.
 				if(!$scope.activities.errors)
 				{
 					DataService.saveActivities($scope.userId, $scope.dataset.Id, $scope.activities);

--- a/DataTracker/js/controllers/dataview-controller.js
+++ b/DataTracker/js/controllers/dataview-controller.js
@@ -75,7 +75,8 @@ mod_dv.controller('DatasetViewCtrl', ['$scope','$routeParams','DataService','$mo
 	    			ChartService.buildChart($scope, $scope.grid.Details, $scope.dataset.Datastore.TablePrefix);
 
 	    			//if we have more than 1 row qa status then show them.
-		    		if($scope.dataset.RowQAStatuses.length > 1)
+		    		//if ($scope.dataset.RowQAStatuses.length > 1)
+		    		if (($scope.dataset.Datastore.TablePrefix !== "FishScales") && ($scope.dataset.RowQAStatuses.length > 1))
 		    		{
 		    			$scope.datasheetColDefs.unshift(
 				    	{
@@ -124,6 +125,7 @@ mod_dv.controller('DatasetViewCtrl', ['$scope','$routeParams','DataService','$mo
 		    		$scope.recalculateGridWidth($scope.datasheetColDefs.length);
 				}
 				$scope.query.loading = false;
+
 
 				$scope.RowQAStatuses =  $rootScope.RowQAStatuses = makeObjects($scope.dataset.RowQAStatuses, 'Id', 'Name');  //Row qa status ids
 


### PR DESCRIPTION
The changes do the following.
On the Activities page, limit the locations on the map to only those belonging to the dataset.
Hide the Instrument, Location, Row QA Status, and a couple other fields, as applicable on the new datasets.

In addition to the code changes, you will also need to run this SQL, substituting the CDMS_TEST_SITKA for your database of course.

update [CDMS_TEST_SITKA].[dbo].[Datasets]
set [Config] = '{"DataEntryPage": {"HiddenFields": ["Instrument","Location"]}}'
where 
--[Id] = 1224
[Name] like '%Fish Scales%'

SELECT *
  FROM [CDMS_TEST_SITKA].[dbo].[Datasets]
  where [Name] like '%Fish Scales%'
